### PR TITLE
Add HAG prediction pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,36 @@ Given the coupled VM stack checkpoint, the full network can be trained using:
 python train_straightpcf.py --val_freq=2000 --train_cvm_network=True --feat_embedding_dim=128 --decoder_hidden_dim=64
 ```
 
-The folder for each training run is placed within ```./logs``` and you can access the necessary checkpoints there. 
+The folder for each training run is placed within ```./logs``` and you can access the necessary checkpoints there.
+
+## Predicting Height Above Ground (HAG)
+
+We provide a simple pipeline to regress HAG values directly from XYZ point
+coordinates stored in LAS/LAZ files.  Training and validation require files
+that contain both XYZ and a ``HAG`` attribute, while test files only need
+XYZ.  Predictions are written back to new LAS/LAZ files containing the
+estimated ``HAG`` attribute.
+
+First install the additional dependency:
+
+```
+pip install laspy
+```
+
+To train the predictor (data expected under ``./data/train`` and
+``./data/val``):
+
+```
+python train_hag.py --epochs=20 --batch-size=4096
+```
+
+Given a trained checkpoint, HAG values for files in ``./data/test`` can be
+generated with:
+
+```
+python predict_hag.py --checkpoint path/to/hag_predictor.pth
+```
+
 
 ## Acknowledgement and citation
 Our code is partially based on ``Score-Based Point Cloud Denoising`` by Shitong Luo and Wei Hu. Kudos to them for their excellent implementation and resources. Please check their GitHub repo [here](https://github.com/luost26/score-denoise).

--- a/datasets/laz_hag_dataset.py
+++ b/datasets/laz_hag_dataset.py
@@ -1,0 +1,62 @@
+import os
+import glob
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+import laspy
+
+class LazHAGDataset(Dataset):
+    """Dataset for reading LAS/LAZ files with optional HAG field.
+
+    Parameters
+    ----------
+    root : str
+        Root directory containing the ``train``, ``val`` or ``test`` folders.
+    split : str
+        One of ``'train'``, ``'val'`` or ``'test'`` specifying which sub-folder
+        to read from.
+    with_hag : bool, optional
+        If ``True`` the dataset expects the input files to contain a ``HAG``
+        (height above ground) dimension and will return point/HAG pairs.  If
+        ``False`` only the XYZ coordinates are returned.  This is useful for
+        the test phase where ground truth HAG values are not available.
+    """
+
+    def __init__(self, root: str, split: str = "train", with_hag: bool = True):
+        super().__init__()
+        self.with_hag = with_hag
+        split_dir = os.path.join(root, split)
+        if not os.path.isdir(split_dir):
+            raise FileNotFoundError(f"Split directory '{split_dir}' was not found")
+        # Accept both LAS and LAZ extensions
+        files = sorted(glob.glob(os.path.join(split_dir, "*.la[sz]")))
+        if len(files) == 0:
+            raise FileNotFoundError(f"No LAS/LAZ files found in '{split_dir}'")
+
+        pts = []
+        hags = []
+        for fp in files:
+            las = laspy.read(fp)
+            xyz = np.vstack((las.x, las.y, las.z)).T.astype(np.float32)
+            pts.append(xyz)
+            if self.with_hag:
+                if "HAG" in las.point_format.extra_dimension_names:
+                    hag = las["HAG"].astype(np.float32)
+                elif "hag" in las.point_format.extra_dimension_names:
+                    hag = las["hag"].astype(np.float32)
+                else:
+                    raise ValueError(f"HAG dimension not found in file '{fp}'")
+                hags.append(hag.reshape(-1, 1))
+        self.xyz = np.concatenate(pts, axis=0)
+        if self.with_hag:
+            self.hag = np.concatenate(hags, axis=0)
+
+    def __len__(self):
+        return self.xyz.shape[0]
+
+    def __getitem__(self, idx):
+        xyz = torch.from_numpy(self.xyz[idx])
+        if self.with_hag:
+            hag = torch.from_numpy(self.hag[idx])
+            return {"xyz": xyz, "hag": hag}
+        return {"xyz": xyz}

--- a/models/hag_predictor.py
+++ b/models/hag_predictor.py
@@ -1,0 +1,20 @@
+import torch
+import torch.nn as nn
+
+
+class HAGPredictor(nn.Module):
+    """Simple multilayer perceptron to regress HAG from XYZ coordinates."""
+
+    def __init__(self, in_dim: int = 3, hidden_dim: int = 64, num_layers: int = 4):
+        super().__init__()
+        layers = []
+        dim = in_dim
+        for _ in range(num_layers - 1):
+            layers.append(nn.Linear(dim, hidden_dim))
+            layers.append(nn.ReLU())
+            dim = hidden_dim
+        layers.append(nn.Linear(dim, 1))
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, xyz: torch.Tensor) -> torch.Tensor:
+        return self.net(xyz)

--- a/predict_hag.py
+++ b/predict_hag.py
@@ -1,0 +1,43 @@
+import os
+import glob
+import argparse
+import numpy as np
+import torch
+import laspy
+
+from models.hag_predictor import HAGPredictor
+
+
+def predict():
+    parser = argparse.ArgumentParser(description="Predict HAG for LAZ files")
+    parser.add_argument("--data-root", default="./data", help="Root directory containing test folder")
+    parser.add_argument("--checkpoint", required=True, help="Path to trained model checkpoint")
+    parser.add_argument("--hidden-dim", type=int, default=64)
+    parser.add_argument("--layers", type=int, default=4)
+    parser.add_argument("--out-dir", default="./predictions", help="Directory to store predicted LAZ files")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = HAGPredictor(hidden_dim=args.hidden_dim, num_layers=args.layers).to(device)
+    model.load_state_dict(torch.load(args.checkpoint, map_location=device))
+    model.eval()
+
+    test_dir = os.path.join(args.data_root, "test")
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    for fp in sorted(glob.glob(os.path.join(test_dir, "*.la[sz]"))):
+        las = laspy.read(fp)
+        xyz = np.vstack((las.x, las.y, las.z)).T.astype(np.float32)
+        xyz_tensor = torch.from_numpy(xyz).to(device)
+        with torch.no_grad():
+            pred_hag = model(xyz_tensor).cpu().numpy().squeeze()
+        if "HAG" not in las.point_format.extra_dimension_names:
+            las.add_extra_dim(laspy.ExtraBytesParams(name="HAG", type=np.float32))
+        las["HAG"] = pred_hag.astype(np.float32)
+        out_fp = os.path.join(args.out_dir, os.path.basename(fp))
+        las.write(out_fp)
+        print(f"Wrote predictions to {out_fp}")
+
+
+if __name__ == "__main__":
+    predict()

--- a/train_hag.py
+++ b/train_hag.py
@@ -1,0 +1,58 @@
+import os
+import argparse
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from datasets.laz_hag_dataset import LazHAGDataset
+from models.hag_predictor import HAGPredictor
+
+
+def train():
+    parser = argparse.ArgumentParser(description="Train HAG predictor")
+    parser.add_argument("--data-root", default="./data", help="Root directory containing train/val/test folders")
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=1024)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--hidden-dim", type=int, default=64)
+    parser.add_argument("--layers", type=int, default=4)
+    parser.add_argument("--out-dir", default="./logs/hag", help="Where to store checkpoints")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    train_ds = LazHAGDataset(args.data_root, split="train", with_hag=True)
+    val_ds = LazHAGDataset(args.data_root, split="val", with_hag=True)
+    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True, num_workers=4)
+    val_loader = DataLoader(val_ds, batch_size=args.batch_size, shuffle=False, num_workers=4)
+
+    model = HAGPredictor(hidden_dim=args.hidden_dim, num_layers=args.layers).to(device)
+    opt = torch.optim.Adam(model.parameters(), lr=args.lr)
+    criterion = torch.nn.MSELoss()
+
+    for epoch in range(args.epochs):
+        model.train()
+        for batch in train_loader:
+            xyz = batch["xyz"].to(device)
+            hag = batch["hag"].to(device)
+            pred = model(xyz).squeeze()
+            loss = criterion(pred, hag.squeeze())
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+        model.eval()
+        with torch.no_grad():
+            val_losses = []
+            for batch in val_loader:
+                xyz = batch["xyz"].to(device)
+                hag = batch["hag"].to(device)
+                pred = model(xyz).squeeze()
+                val_losses.append(criterion(pred, hag.squeeze()).item())
+        print(f"Epoch {epoch+1}/{args.epochs}: val_loss={np.mean(val_losses):.6f}")
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    torch.save(model.state_dict(), os.path.join(args.out_dir, "hag_predictor.pth"))
+
+
+if __name__ == "__main__":
+    train()


### PR DESCRIPTION
## Summary
- add LazHAGDataset for reading LAS/LAZ files with optional HAG attribute
- implement simple MLP (HAGPredictor) for regressing height above ground from XYZ
- add training and prediction scripts and README instructions

## Testing
- `python -m py_compile datasets/laz_hag_dataset.py models/hag_predictor.py train_hag.py predict_hag.py`
- `python train_hag.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy laspy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68bec3d2c0cc832a831c1de9186cb90e